### PR TITLE
add: scope options InheritCache and SyncState

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ func handler() {
 }
 ```
 
+You can configure the behavior of the scope with respect to the instance cache with the `WithCacheMode` option:
+```go
+// for example
+scope, cleanup := manioc.OpenScope(
+  manioc.WithParentScope(ctr),
+  manioc.WithCacheMode(InheritCacheMode),
+)
+```
+The following three modes are available:
+- `DefaultCacheMode`: Instance caches are independent across scopes. Even if the parent scope is closed, the child scope will remain open.
+- `InheritCacheMode`: In this mode, when a child scope is opened, it inherits the instance cache of the parent scope. When the parent scope is closed, the child scopes are also automatically closed.
+- `SyncCacheMode`: In this mode, the parent and child scopes share the instance cache. When the parent scope is closed, the child scopes are also automatically closed.
+
+Note that these modes only affect instance caches for dependencies registered with `ScopedCache` cache policy, not for `NeverCache` and `GlobalCache` policies.
+
 ### 5. Constructor / Field Injection
 
 In this library, dependency injection is performed on constructors or fields.

--- a/container.go
+++ b/container.go
@@ -10,7 +10,10 @@ func (c *defaultContainer) getRegisterContext() registerContext {
 
 func newDefaultContainer() *defaultContainer {
 	return &defaultContainer{
-		defaultScope: defaultScope{context: newDefaultContext()},
+		defaultScope: defaultScope{
+			context:     newDefaultContext(),
+			childScopes: make([]Scope, 0),
+		},
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -89,7 +89,8 @@ func WithResolveKey(key any) ResolveOption {
 //
 
 type openScopeOptions struct {
-	parent Scope
+	parent    Scope
+	cacheMode ScopeCacheMode
 }
 
 type OpenScopeOption interface {
@@ -106,4 +107,16 @@ func (opt *withParentScope) apply(options *openScopeOptions) {
 
 func WithParentScope(parent Scope) OpenScopeOption {
 	return &withParentScope{parent: parent}
+}
+
+// WithCacheMode
+
+type withCacheMode struct{ cacheMode ScopeCacheMode }
+
+func (opt *withCacheMode) apply(options *openScopeOptions) {
+	options.cacheMode = opt.cacheMode
+}
+
+func WithCacheMode(cacheMode ScopeCacheMode) OpenScopeOption {
+	return &withCacheMode{cacheMode: cacheMode}
 }

--- a/scope.go
+++ b/scope.go
@@ -1,7 +1,8 @@
 package manioc
 
 type defaultScope struct {
-	context *defaultContext
+	context     *defaultContext
+	childScopes []Scope
 }
 
 func (c *defaultScope) getResolveContext() resolveContext {
@@ -11,34 +12,55 @@ func (c *defaultScope) getResolveContext() resolveContext {
 	return c.context
 }
 
-func (c *defaultScope) createScope() (Scope, func()) {
+func (c *defaultScope) createScope(mode ScopeCacheMode) (Scope, func()) {
 	ret := &defaultScope{
 		context: &defaultContext{
 			registry: c.context.registry,
 			cache:    make(map[any]any),
 		},
+		childScopes: make([]Scope, 0),
+	}
+	if mode == InheritCacheMode {
+		// inherit parent cache
+		for k, v := range c.context.cache {
+			ret.context.cache[k] = v
+		}
+		// register child scope into parent
+		c.childScopes = append(c.childScopes, ret)
+	} else if mode == SyncCacheMode {
+		// syncrhonize cache
+		ret.context.cache = c.context.cache
+		// register child scope into parent
+		c.childScopes = append(c.childScopes, ret)
 	}
 	cleanup := func() {
 		// after this function is called, this scope is no longer available.
-		ret.context = nil
+		ret.closeScope()
 	}
 	return ret, cleanup
 }
 
+func (c *defaultScope) closeScope() {
+	for _, scope := range c.childScopes {
+		scope.closeScope()
+	}
+	c.childScopes = nil
+	c.context = nil
+}
+
 // Create new child scope.
-// The created scope inherits dependency registration,
-// but does not inherit the instance cache.
 // The second return value is a cleanup function, which you can call it
 // to explicitly close the scope. After this function is called,
 // the resolution request for the corresponding scope will not work.
 func OpenScope(opts ...OpenScopeOption) (Scope, func()) {
 	// merge options
 	options := &openScopeOptions{
-		parent: globalContainer,
+		parent:    globalContainer,
+		cacheMode: DefaultCacheMode,
 	}
 	for _, opt := range opts {
 		opt.apply(options)
 	}
 	// create scoped container
-	return options.parent.createScope()
+	return options.parent.createScope(options.cacheMode)
 }

--- a/tests/container_and_scope/container_and_scope_test.go
+++ b/tests/container_and_scope/container_and_scope_test.go
@@ -46,7 +46,7 @@ func Test_ContainerAndScope(t *testing.T) {
 	assert.Nil(err)
 }
 
-func Test_NestedScope(t *testing.T) {
+func Test_Scope_WithDefaultCacheMode(t *testing.T) {
 	assert := assert.New(t)
 
 	// setup container
@@ -55,33 +55,163 @@ func Test_NestedScope(t *testing.T) {
 	// register IMyService with ScopedCache policy
 	assert.Nil(manioc.RegisterScoped[IMyService, MyService](manioc.WithContainer(ctr)))
 
-	// open scope
+	// resolve in parent scope
+	ret := manioc.MustResolve[IMyService](manioc.WithScope(ctr))
+
+	// open scope, without inherit/sync instance caches
+	scope, cleanup := manioc.OpenScope(
+		manioc.WithParentScope(ctr),
+		// manioc.WithCacheMode(manioc.DefaultCacheMode),
+	)
+	defer cleanup()
+	retScoped := manioc.MustResolve[IMyService](manioc.WithScope(scope))
+
+	// in DefaultCacheMode, instance caches are independent across scopes
+	assert.NotSame(ret, retScoped)
+}
+
+func Test_Scope_WithInheritCacheMode(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup container
+	ctr := manioc.NewContainer()
+
+	// register IMyService with ScopedCache policy
+	assert.Nil(manioc.RegisterScoped[IMyService, MyService](manioc.WithContainer(ctr)))
+
+	// resolve in parent scope
+	ret := manioc.MustResolve[IMyService](manioc.WithScope(ctr))
+
+	// open scope, inherit instance caches
+	scope, cleanup := manioc.OpenScope(
+		manioc.WithParentScope(ctr),
+		manioc.WithCacheMode(manioc.InheritCacheMode),
+	)
+	defer cleanup()
+	retScoped := manioc.MustResolve[IMyService](manioc.WithScope(scope))
+
+	// since the cache is inherited, the resolution results will match
+	assert.Same(ret, retScoped)
+}
+
+func Test_Scope_WithSyncCacheMode(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup container
+	ctr := manioc.NewContainer()
+
+	// register IMyService with ScopedCache policy
+	assert.Nil(manioc.RegisterScoped[IMyService, MyService](manioc.WithContainer(ctr)))
+	assert.Nil(manioc.RegisterScoped[IMyService, MyService](
+		manioc.WithContainer(ctr),
+		manioc.WithRegisterKey("another"),
+	))
+
+	// resolve in parent scope
+	ret := manioc.MustResolve[IMyService](manioc.WithScope(ctr))
+
+	// open scope, sync instance caches
+	scope, cleanup := manioc.OpenScope(
+		manioc.WithParentScope(ctr),
+		manioc.WithCacheMode(manioc.SyncCacheMode),
+	)
+	defer cleanup()
+	retScoped := manioc.MustResolve[IMyService](manioc.WithScope(scope))
+
+	// since the cache is synced, the resolution results will match
+	assert.Same(ret, retScoped)
+
+	// resolve in child scope
+	ret2Scoped := manioc.MustResolve[IMyService](
+		manioc.WithScope(scope),
+		manioc.WithResolveKey("another"),
+	)
+
+	// since the cache is synced, the resolution results will match
+	ret2 := manioc.MustResolve[IMyService](
+		manioc.WithScope(ctr),
+		manioc.WithResolveKey("another"),
+	)
+	assert.Same(ret2Scoped, ret2)
+}
+
+func Test_NestedScope_WithDefaultCacheMode(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup container
+	ctr := manioc.NewContainer()
+	assert.Nil(manioc.RegisterScoped[IMyService, MyService](manioc.WithContainer(ctr)))
+
+	// open parent scope
 	scope, cleanup := manioc.OpenScope(manioc.WithParentScope(ctr))
-	// resolve within the scope
-	ret, err := manioc.Resolve[IMyService](manioc.WithScope(scope))
-	assert.NotNil(ret)
-	assert.Nil(err)
 
 	// open child scope
-	childScope, childCleanup := manioc.OpenScope(manioc.WithParentScope(scope))
-	// resolve within the child scope
-	childRet, childErr := manioc.Resolve[IMyService](manioc.WithScope(childScope))
-	assert.NotNil(childRet)
-	assert.Nil(childErr)
+	childScope, _ := manioc.OpenScope(
+		manioc.WithParentScope(scope),
+		// manioc.WithCacheMode(manioc.DefaultCacheMode),
+	)
 
-	// Since a scope does not inherit the instance cache,
-	// resolution in different scopes would produce different instances.
-	// We would like to make this behavior configurable.
-	assert.NotSame(ret, childRet)
-
-	// close scope
+	// close parent
 	cleanup()
+	_, err := manioc.Resolve[IMyService](manioc.WithScope(scope))
+	assert.Error(err)
 
-	// Currently, when the parent scope is closed, the child scope will not be closed.
-	// This behavior may be inappropriate if the cache is inherited.
-	_, childErr = manioc.Resolve[IMyService](manioc.WithScope(childScope))
-	assert.Nil(childErr)
+	// in DefaultCacheMode, the child scope remains open even if the parent scope is closed
+	ret, err := manioc.Resolve[IMyService](manioc.WithScope(childScope))
+	assert.NotNil(ret)
+	assert.Nil(err)
+}
 
-	// close child scope
-	childCleanup()
+func Test_NestedScope_WithInheritCacheMode(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup container
+	ctr := manioc.NewContainer()
+	assert.Nil(manioc.RegisterScoped[IMyService, MyService](manioc.WithContainer(ctr)))
+
+	// open parent scope
+	scope, cleanup := manioc.OpenScope(manioc.WithParentScope(ctr))
+
+	// open child scope
+	childScope, _ := manioc.OpenScope(
+		manioc.WithParentScope(scope),
+		manioc.WithCacheMode(manioc.InheritCacheMode),
+	)
+
+	// close parent
+	cleanup()
+	_, err := manioc.Resolve[IMyService](manioc.WithScope(scope))
+	assert.Error(err)
+
+	// if you using InheritCacheMode, when the parent scope is closed,
+	// then automatically the child scope is also closed.
+	_, err = manioc.Resolve[IMyService](manioc.WithScope(childScope))
+	assert.Error(err)
+}
+
+func Test_NestedScope_WithSyncCacheMode(t *testing.T) {
+	assert := assert.New(t)
+
+	// setup container
+	ctr := manioc.NewContainer()
+	assert.Nil(manioc.RegisterScoped[IMyService, MyService](manioc.WithContainer(ctr)))
+
+	// open parent scope
+	scope, cleanup := manioc.OpenScope(manioc.WithParentScope(ctr))
+
+	// open child scope
+	childScope, _ := manioc.OpenScope(
+		manioc.WithParentScope(scope),
+		manioc.WithCacheMode(manioc.SyncCacheMode),
+	)
+
+	// close parent
+	cleanup()
+	_, err := manioc.Resolve[IMyService](manioc.WithScope(scope))
+	assert.Error(err)
+
+	// if you using InheritCacheMode, when the parent scope is closed,
+	// then automatically the child scope is also closed.
+	_, err = manioc.Resolve[IMyService](manioc.WithScope(childScope))
+	assert.Error(err)
 }

--- a/types.go
+++ b/types.go
@@ -19,6 +19,22 @@ const (
 	NeverCache
 )
 
+// ScopeCacheMode is an enumeration type that configures the behavior of
+// the scope with respect to its instance cache.
+type ScopeCacheMode int
+
+const (
+	// Instance caches are independent across scopes.
+	// Even if the parent scope is closed, the child scope will remain open.
+	DefaultCacheMode ScopeCacheMode = iota
+	// When a child scope is opened, it inherits the instance cache of the parent scope.
+	// When the parent scope is closed, the child scopes are also automatically closed.
+	InheritCacheMode
+	// The parent and child scopes share the instance cache.
+	// When the parent scope is closed, the child scopes are also automatically closed.
+	SyncCacheMode
+)
+
 // Activator is a function that creates a service instance on given context.
 type activator func(ctx resolveContext) (any, error)
 
@@ -41,7 +57,8 @@ type registerContext interface {
 // Scope is an interface that expresses the cache scope of a container.
 type Scope interface {
 	getResolveContext() resolveContext
-	createScope() (Scope, func())
+	createScope(mode ScopeCacheMode) (Scope, func())
+	closeScope()
 }
 
 // Container is an interface for storing dependencies.


### PR DESCRIPTION
close #17 
This PR introduces a new option; `WithCacheMode` to configure the behavior of scopes with respect to instance caching.